### PR TITLE
Fix route for Triase IGD report to use correct class

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -354,7 +354,7 @@ Route::prefix('admin')
                 Route::get('laporan-pasien-cob', Casemix\LaporanPasienCob::class)
                     ->name('laporan-pasien-cob')
                     ->middleware('can:casemix.laporan-pasien-cob.read');
-                Route::get('laporan-triase-igd-zona-hijau', Casemix\LaporanTriaseIGDZonaHijau::class)
+                Route::get('laporan-triase-igd-zona-hijau', Casemix\LaporanTriaseIgdZonaHijau::class)
                     ->name('laporan-triase-igd-zona-hijau')
                     ->middleware('can:casemix.laporan-triase-igd-zona-hijau.read');
             });


### PR DESCRIPTION
Pull request ini mencakup perubahan kecil untuk memperbaiki kesalahan penulisan (typo) pada nama kelas dalam definisi rute di file `routes/web.php`.

* **Perbaikan Bug:**

  * Diperbaiki nama kelas pada definisi rute `laporan-triase-igd-zona-hijau` dari `Casemix\LaporanTriaseIGDZonaHijau` menjadi `Casemix\LaporanTriaseIgdZonaHijau` agar fungsi berjalan dengan benar.
