### PR TITLE
Fix Menu Kunjungan Per Bentuk Obat

### DIFF
--- a/app/Livewire/Pages/Farmasi/KunjunganPerBentukObat.php
+++ b/app/Livewire/Pages/Farmasi/KunjunganPerBentukObat.php
@@ -107,6 +107,7 @@ class KunjunganPerBentukObat extends Component
             'selisih'       => time_length($model->waktu_validasi, $model->waktu_penyerahan),
             'total'         => $model->total,
             'jumlah'        => $model->jumlah,
+            'jml_dr'        => $model->jml_dr
         ];
 
         return [
@@ -139,6 +140,7 @@ class KunjunganPerBentukObat extends Component
             'Lama Penyelesaian',
             'Total Pembelian (RP)',
             'Jumlah Obat',
+            'Jumlah Diracik'
         ];
     }
 

--- a/app/Models/Farmasi/ResepObat.php
+++ b/app/Models/Farmasi/ResepObat.php
@@ -102,7 +102,8 @@ class ResepObat extends Model
             dokter.nm_dokter,
             poliklinik.nm_poli,
             (select round(sum(detail_pemberian_obat.total)) from detail_pemberian_obat where detail_pemberian_obat.no_rawat = resep_obat.no_rawat and detail_pemberian_obat.tgl_perawatan = resep_obat.tgl_perawatan and detail_pemberian_obat.jam = resep_obat.jam) as total,
-            (select count(*) from detail_pemberian_obat where detail_pemberian_obat.no_rawat = resep_obat.no_rawat and detail_pemberian_obat.tgl_perawatan = resep_obat.tgl_perawatan and detail_pemberian_obat.jam = resep_obat.jam) as jumlah
+            (select count(*) from detail_pemberian_obat where detail_pemberian_obat.no_rawat = resep_obat.no_rawat and detail_pemberian_obat.tgl_perawatan = resep_obat.tgl_perawatan and detail_pemberian_obat.jam = resep_obat.jam) as jumlah,
+            (select round(sum(obat_racikan.jml_dr)) from obat_racikan where obat_racikan.no_rawat = resep_obat.no_rawat and obat_racikan.tgl_perawatan = resep_obat.tgl_perawatan and obat_racikan.jam = resep_obat.jam) as jml_dr
             SQL;
 
         $this->addSearchConditions([

--- a/resources/views/livewire/pages/farmasi/kunjungan-per-bentuk-obat.blade.php
+++ b/resources/views/livewire/pages/farmasi/kunjungan-per-bentuk-obat.blade.php
@@ -122,6 +122,7 @@
                                 <x-table.th style="width: 14ch" name="selisih" title="Selisih Waktu" />
                                 <x-table.th style="width: 20ch" name="total" title="Total Pembelian" />
                                 <x-table.th name="jumlah" title="Jumlah" />
+                                <x-table.th name="jml_dr" title="Jumlah Diracik" />
                             </x-slot>
                             <x-slot name="body">
                                 @forelse ($this->dataKunjunganResepObatRacikan as $resep)
@@ -171,9 +172,12 @@
                                         <x-table.td>
                                             {{ $resep->jumlah }}
                                         </x-table.td>
+                                        <x-table.td>
+                                            {{ $resep->jml_dr }}
+                                        </x-table.td>
                                     </x-table.tr>
                                 @empty
-                                    <x-table.tr-empty colspan="13" padding />
+                                    <x-table.tr-empty colspan="14" padding />
                                 @endforelse
                             </x-slot>
                         </x-table>


### PR DESCRIPTION
Pull request ini menambahkan dukungan untuk menampilkan jumlah obat racikan dalam laporan kunjungan farmasi. Perubahan ini memastikan bahwa kolom baru "Jumlah Diracik" disertakan dalam pengambilan data, header tabel, dan isi tabel pada komponen Livewire serta tampilan Blade terkait.

**Pembaruan Model Data dan Query:**
* Memperbarui method `scopeKunjunganResep` di `ResepObat.php` untuk menyertakan field baru `jml_dr`, yang menghitung total jumlah obat racikan per resep menggunakan subquery.

**Pembaruan Komponen Livewire:**
* Memodifikasi method `dataPerSheet` di `KunjunganPerBentukObat.php` untuk menyertakan nilai `jml_dr` dalam array data yang dikembalikan.
* Menambahkan "Jumlah Diracik" ke header kolom di method `columnHeaders` pada `KunjunganPerBentukObat.php`.

**Pembaruan Tampilan Blade:**
* Menambahkan kolom baru "Jumlah Diracik" pada header tabel dan isi tabel di `kunjungan-per-bentuk-obat.blade.php`. [[1]](diffhunk://#diff-99abb011ebd3e12d132ad4434dcd2c29cdc916b9388b8d36a401838332c5a896R125) [[2]](diffhunk://#diff-99abb011ebd3e12d132ad4434dcd2c29cdc916b9388b8d36a401838332c5a896R175-R180)
