### PR TITLE
fix: marquee problem on dashboard antrean farmasi

### DIFF
--- a/app/Livewire/Pages/Informasi/AntreanFarmasi/ListPengerjaan.php
+++ b/app/Livewire/Pages/Informasi/AntreanFarmasi/ListPengerjaan.php
@@ -7,7 +7,12 @@ use Livewire\Component;
 
 class ListPengerjaan extends Component
 {
-    protected $listeners = ['marqueePengerjaanFinished' => '$refresh'];
+    protected $listeners = ['marqueePengerjaanFinished' => 'refreshData'];
+
+    public function refreshData()
+    {
+        $this->emitSelf('$refresh');
+    }
 
     public function getDataPengerjaanProperty()
     {

--- a/app/Livewire/Pages/Informasi/AntreanFarmasi/ListPenyerahan.php
+++ b/app/Livewire/Pages/Informasi/AntreanFarmasi/ListPenyerahan.php
@@ -7,8 +7,13 @@ use Livewire\Component;
 
 class ListPenyerahan extends Component
 {
-    protected $listeners = ['marqueePenyerahanFinished' => '$refresh'];
+    protected $listeners = ['marqueePenyerahanFinished' => 'refreshData'];
 
+    public function refreshData()
+    {
+        $this->emitSelf('$refresh');
+    }
+    
     public function getDataPenyerahanProperty()
     {
         return ResepObat::query()->antreanFarmasiRawatJalan('penyerahan')->get();

--- a/resources/views/livewire/pages/informasi/antrean-farmasi/list-pengerjaan.blade.php
+++ b/resources/views/livewire/pages/informasi/antrean-farmasi/list-pengerjaan.blade.php
@@ -24,10 +24,10 @@
                 id="marquee-pengerjaan"
                 wire:key="marquee-pengerjaan-{{ $this->dataPengerjaan->count() }}"
                 class="marquee bg-white"
-                @if ($this->dataPengerjaan->count() < 20) wire:poll.300s @endif
+                @if ($this->dataPengerjaan->count() < 10) wire:poll.300s @endif
                 data-row-count="{{ $this->dataPengerjaan->count() }}"
                 data-direction="up"
-                data-duration="20000"
+                data-duration="30000"
                 startVisible="true"
                 data-gap="10"
                 data-duplicated="false"
@@ -67,28 +67,23 @@
             let marqueePengerjaan = $('#marquee-pengerjaan');
             let rowCount = parseInt(marqueePengerjaan.data('row-count'));
 
-            if (rowCount > 20) {
-                if (marqueePengerjaan.hasClass('js-marquee')) {
-                    marqueePengerjaan.marquee('destroy');
-                }
-
+            if (rowCount > 10) {
+                marqueePengerjaan.marquee('destroy');
+                marqueePengerjaan.find('.js-marquee-wrapper').remove();
                 marqueePengerjaan.marquee();
-
                 marqueePengerjaan.off('finished').on('finished', function() {
                     $(this).marquee('destroy');
-                    Livewire.emit('marqueePengerjaanFinished');
+                    Livewire.emitTo('pages.informasi.antrean-farmasi.list-pengerjaan', 'marqueePengerjaanFinished');
                 });
-            } else {
-                if (marqueePengerjaan.hasClass('js-marquee')) {
-                    marqueePengerjaan.marquee('destroy');
-                }
             }
         }
 
         document.addEventListener("DOMContentLoaded", initMarqueePengerjaan);
 
         Livewire.hook('message.processed', (message, component) => {
-            initMarqueePengerjaan();
+            if (component.fingerprint.name === 'pages.informasi.antrean-farmasi.list-pengerjaan') {
+                initMarqueePengerjaan();
+            }
         });
     </script>
 @endpush

--- a/resources/views/livewire/pages/informasi/antrean-farmasi/list-penyerahan.blade.php
+++ b/resources/views/livewire/pages/informasi/antrean-farmasi/list-penyerahan.blade.php
@@ -25,10 +25,10 @@
                 id="marquee-penyerahan"
                 wire:key="marquee-penyerahan-{{ $this->dataPenyerahan->count() }}"
                 class="marquee bg-white"
-                @if ($this->dataPenyerahan->count() < 20) wire:poll.300s @endif
+                @if ($this->dataPenyerahan->count() < 10) wire:poll.300s @endif
                 data-row-count="{{ $this->dataPenyerahan->count() }}"
                 data-direction="up"
-                data-duration="20000"
+                data-duration="30000"
                 startVisible="true"
                 data-gap="10"
                 data-duplicated="false"
@@ -68,28 +68,23 @@
             let marqueePenyerahan = $('#marquee-penyerahan');
             let rowCount = parseInt(marqueePenyerahan.data('row-count'));
 
-            if (rowCount > 20) {
-                if (marqueePenyerahan.hasClass('js-marquee')) {
-                    marqueePenyerahan.marquee('destroy');
-                }
-
+            if (rowCount > 10 ) {
+                marqueePenyerahan.marquee('destroy');
+                marqueePenyerahan.find('.js-marquee-wrapper').remove();
                 marqueePenyerahan.marquee();
-
                 marqueePenyerahan.off('finished').on('finished', function() {
                     $(this).marquee('destroy');
-                    Livewire.emit('marqueePenyerahanFinished');
+                    Livewire.emitTo('pages.informasi.antrean-farmasi.list-penyerahan', 'marqueePenyerahanFinished');
                 });
-            } else {
-                if (marqueePenyerahan.hasClass('js-marquee')) {
-                    marqueePenyerahan.marquee('destroy');
-                }
             }
         }
 
         document.addEventListener("DOMContentLoaded", initMarqueePenyerahan);
 
         Livewire.hook('message.processed', (message, component) => {
-            initMarqueePenyerahan();
+            if (component.fingerprint.name === 'pages.informasi.antrean-farmasi.list-penyerahan') {
+                initMarqueePenyerahan();
+            }
         });
     </script>
 @endpush


### PR DESCRIPTION
This pull request updates the behavior and configuration of the pharmacy queue ("Antrean Farmasi") displays, specifically for the "Pengerjaan" (processing) and "Penyerahan" (handover) lists. The changes focus on improving how the marquees (scrolling lists) refresh and are managed based on the number of items, as well as optimizing event handling and polling intervals.

**Marquee Configuration and Behavior Adjustments:**

* Reduced the threshold for enabling Livewire polling from 20 to 10 items and increased the marquee duration from 20,000ms to 30,000ms in both `list-pengerjaan.blade.php` and `list-penyerahan.blade.php`. This makes the display less aggressive in polling and allows items to scroll more slowly for better readability. [[1]](diffhunk://#diff-884489fa0ca5af85e8c2e6c6a19987891d6741ce2f25e2d5e9cbfb7c5ae77e2fL27-R30) [[2]](diffhunk://#diff-8e2d3d948b4a290b81394f43e8e3906aff4721f080d53b082693bc44d7984925L28-R31)
* Changed the JavaScript logic so that marquees are only (re)initialized and destroyed when there are more than 10 items, instead of 20. Also, improved the cleanup process by removing the `.js-marquee-wrapper` and ensured event emission is targeted to the correct Livewire component using `emitTo`. [[1]](diffhunk://#diff-884489fa0ca5af85e8c2e6c6a19987891d6741ce2f25e2d5e9cbfb7c5ae77e2fL70-R86) [[2]](diffhunk://#diff-8e2d3d948b4a290b81394f43e8e3906aff4721f080d53b082693bc44d7984925L71-R87)

**Livewire Event Handling Improvements:**

* Updated the Livewire components (`ListPengerjaan` and `ListPenyerahan`) to use a dedicated `refreshData` method instead of directly calling `$refresh` via event listeners. This method now emits a self-refresh, making the refresh logic more explicit and maintainable. [[1]](diffhunk://#diff-1220259f626b8e6444a7f7ccc7f6cd9e6b14e473e8779c72839247a9f0faa42fL10-R15) [[2]](diffhunk://#diff-f4ac3bd44583de713a50d65c59cebb94f1052266ab3c46ecf07db6988d378b7dL10-R15)