### PR TITLE
feat: add display for current patient in examination

### DIFF
--- a/app/Livewire/Pages/Antrean/AntreanDiPanggil.php
+++ b/app/Livewire/Pages/Antrean/AntreanDiPanggil.php
@@ -33,6 +33,23 @@ class AntreanDiPanggil extends Component
             ->first();
     }
 
+    public function getAntreanSedangPeriksaProperty()
+    {
+        $db = \DB::connection('mysql_sik')->getDatabaseName();
+        $antripoli = \DB::raw("{$db}.antripoli antripoli");
+
+        return Pintu::query()
+            ->antrianPerPintu($this->kd_pintu)
+            ->selectRaw('antripoli.status')
+            ->leftJoin($antripoli, fn (JoinClause $join) => $join
+                ->on('registrasi.no_rawat', '=', 'antripoli.no_rawat')
+                ->on('poliklinik.kd_poli', '=', 'antripoli.kd_poli')
+                ->on('dokter.kd_dokter', '=', 'antripoli.kd_dokter')
+            )
+            ->where('antripoli.status', '0')
+            ->first();
+    }
+
     public function call(): void
     {
         if ($this->isCalling) {

--- a/resources/views/livewire/pages/antrean/antrean-di-panggil.blade.php
+++ b/resources/views/livewire/pages/antrean/antrean-di-panggil.blade.php
@@ -17,6 +17,22 @@
                 </div>
             </div>
         </div>
+    @elseif ($this->antreanSedangPeriksa)
+        <div class="col">
+            <div class="card card-outline card-info d-flex justify-content-center h-100">
+                <div class="card-header">
+                    <h5 class="text-uppercase">antrean dipanggil</h5>
+                </div>
+                <div class="card-body">
+                    <h5>{{ $this->antreanSedangPeriksa->nm_poli ?? '' }}</h5>
+                    <h5 class="text-uppercase">{{ $this->antreanSedangPeriksa->nm_dokter ?? '' }}</h5>
+                    <h1 class="text-danger" style="font-size: 9rem">
+                        {{ $this->antreanSedangPeriksa->no_reg ?? '' }}
+                    </h1>
+                    <h4>{{ $this->antreanSedangPeriksa->nm_pasien ?? '' }}</h4>
+                </div>
+            </div>
+        </div>
     @else
         <div class="col">
             <div class="card card-outline card-success d-flex justify-content-center h-100">


### PR DESCRIPTION
This pull request adds a new feature to display information about patients currently being examined in the queue system. The main changes include introducing a new computed property in the Livewire component to fetch this data and updating the Blade view to display it when available.

**Backend logic enhancements:**

* Added a new computed property `antreanSedangPeriksa` in `AntreanDiPanggil.php` to retrieve queue entries with status '0' (currently being examined) by joining related tables.

**Frontend display updates:**

* Updated `antrean-di-panggil.blade.php` to show a new card with details (clinic, doctor, registration number, patient name) when `antreanSedangPeriksa` is present.