### PR TITLE
refactor: update layout and styling for table header antrean farmasi

### DIFF
--- a/resources/views/livewire/pages/informasi/antrean-farmasi/list-pengerjaan.blade.php
+++ b/resources/views/livewire/pages/informasi/antrean-farmasi/list-pengerjaan.blade.php
@@ -8,18 +8,14 @@
     </style>
 @endpush
 
-<div class="col-6 pt-2" style="font-size: 1.5vh">
+<div class="col-6 pt-2">
     <div class="card card-outline card-success">
         <div class="card-body">
-            <table class="table table-bordered table-striped">
-                <thead class="bg-success">
-                    <tr>
-                        <th style="width: 60%">Pasien</th>
-                        <th style="width: 20%">Jenis Resep</th>
-                        <th style="width: 20%">Mulai Pengerjaan</th>
-                    </tr>
-                </thead>
-            </table>
+            <div class="bg-success p-2 text-center">
+                <h4 class="text-white font-weight-bold text-uppercase" style="font-size: 4.0vh">
+                    {{__('Sedang Dikerjakan')}}
+                </h4>
+            </div>
             <div
                 id="marquee-pengerjaan"
                 wire:key="marquee-pengerjaan-{{ $this->dataPengerjaan->count() }}"
@@ -32,7 +28,7 @@
                 data-gap="10"
                 data-duplicated="false"
             >
-                <table class="table table-bordered table-striped">
+                <table class="table table-bordered table-striped" style="font-size: 1.5vh">
                     <tbody>
                         @forelse ($this->dataPengerjaan as $item)
                             <tr>

--- a/resources/views/livewire/pages/informasi/antrean-farmasi/list-penyerahan.blade.php
+++ b/resources/views/livewire/pages/informasi/antrean-farmasi/list-penyerahan.blade.php
@@ -8,19 +8,14 @@
     </style>
 @endpush
 
-<div class="col-6 pt-2" style="font-size: 1.5vh">
+<div class="col-6 pt-2">
     <div class="card card-outline card-success">
         <div class="card-body">
-            <table class="table table-bordered table-striped">
-                <thead class="bg-success">
-                    <tr>
-                        <th style="width: 60%">Pasien</th>
-                        <th style="width: 20%">Jenis Resep</th>
-                        <th style="width: 20%">Selesai</th>
-                    </tr>
-                </thead>
-            </table>
-
+            <div class="bg-success p-2 text-center">
+                <h4 class="text-white font-weight-bold text-uppercase" style="font-size: 4.0vh">
+                    {{__('Selesai')}}
+                </h4>
+            </div>
             <div
                 id="marquee-penyerahan"
                 wire:key="marquee-penyerahan-{{ $this->dataPenyerahan->count() }}"
@@ -33,7 +28,7 @@
                 data-gap="10"
                 data-duplicated="false"
             >
-                <table class="table table-bordered table-striped">
+                <table class="table table-bordered table-striped" style="font-size: 1.5vh">
                     <tbody>
                         @forelse ($this->dataPenyerahan as $item)
                             <tr>


### PR DESCRIPTION
This pull request updates the UI for the pharmacy queue information pages to improve clarity and consistency. The changes mainly replace the table headers with more prominent section titles and ensure font sizing is applied directly to the relevant tables.

UI improvements for section headers:

* Replaced the table headers in `list-pengerjaan.blade.php` and `list-penyerahan.blade.php` with visually prominent section titles ("Sedang Dikerjakan" and "Selesai") displayed in a styled header above the marquee content. [[1]](diffhunk://#diff-884489fa0ca5af85e8c2e6c6a19987891d6741ce2f25e2d5e9cbfb7c5ae77e2fL11-R18) [[2]](diffhunk://#diff-8e2d3d948b4a290b81394f43e8e3906aff4721f080d53b082693bc44d7984925L11-R18)

Styling consistency for tables:

* Moved the `font-size: 1.5vh` style from the container div to the actual table element in both files for more precise control over table text size. [[1]](diffhunk://#diff-884489fa0ca5af85e8c2e6c6a19987891d6741ce2f25e2d5e9cbfb7c5ae77e2fL35-R31) [[2]](diffhunk://#diff-8e2d3d948b4a290b81394f43e8e3906aff4721f080d53b082693bc44d7984925L36-R31)