### PR TITLE
fix: add sorting by doctor name in Pintu model's antrian query

### DIFF
--- a/app/Models/Aplikasi/Pintu.php
+++ b/app/Models/Aplikasi/Pintu.php
@@ -83,6 +83,7 @@ class Pintu extends Model
             ->where('registrasi.status_lanjut', '!=', 'ranap')
             ->where('manajemen_pintu.kd_pintu', $kd_pintu)
             ->orderBy('jadwal.jam_mulai', 'asc')
+            ->orderBy('dokter.nm_dokter', 'asc')
             ->orderBy('registrasi.no_reg', 'asc')
             ->groupBy('registrasi.no_rawat');
     }


### PR DESCRIPTION
This pull request makes a small update to the ordering of query results in the `scopeAntrianPerPintu` method. Now, after sorting by `jadwal.jam_mulai`, the results are also sorted by the doctor's name, which helps improve the readability and organization of the queue.

- Query results in `scopeAntrianPerPintu` are now additionally ordered by `dokter.nm_dokter` in ascending order after `jadwal.jam_mulai`.