### PR TITLE
feat: add No. SEP and Status columns to Laporan Triase IGD Zona Hijau

### DIFF
--- a/app/Livewire/Pages/Casemix/LaporanTriaseIgdZonaHijau.php
+++ b/app/Livewire/Pages/Casemix/LaporanTriaseIgdZonaHijau.php
@@ -72,11 +72,13 @@ class LaporanTriaseIgdZonaHijau extends Component
                 ->cursor()
                 ->map(fn (DataTriaseIgd $model) : array => [
                     'No. Rawat'         => $model->no_rawat,
+                    'No. SEP'           => $model->no_sep,
                     'No. RM'            => $model->no_rkm_medis,
                     'Nama Pasien'       => $model->nm_pasien,
                     'Jenis Bayar'       => $model->png_jawab,
                     'Tgl. Kunjungan'    => $model->tgl_kunjungan,
                     'Cara Masuk'        => $model->cara_masuk,
+                    'Status'            => $model->status_lanjut,
                     'Alasan Kedatangan' => $model->alasan_kedatangan,
                     'Macam Kasus'       => $model->macam_kasus,
                     'Zona'              => $model->plan,
@@ -88,11 +90,13 @@ class LaporanTriaseIgdZonaHijau extends Component
     {
         return [
             'No. Rawat',
+            'No. SEP',
             'No. RM',
             'Nama Pasien',
             'Jenis Bayar',
             'Tgl. Kunjungan',
             'Cara Masuk',
+            'Status',
             'Alasan Kedatangan',
             'Macam Kasus',
             'Zona',

--- a/app/Models/Casemix/DataTriaseIgd.php
+++ b/app/Models/Casemix/DataTriaseIgd.php
@@ -31,11 +31,13 @@ class DataTriaseIgd extends Model
 
         $this->addSearchConditions([
             'data_triase_igd.no_rawat',
+            'bridging_sep.no_sep',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',
             'data_triase_igd.tgl_kunjungan',
             'data_triase_igd.cara_masuk',
+            'reg_periksa.status_lanjut',
             'data_triase_igd.alasan_kedatangan',
             'master_triase_macam_kasus.macam_kasus',
             'data_triase_igdsekunder.plan',
@@ -43,11 +45,13 @@ class DataTriaseIgd extends Model
 
         $sqlSelect = <<<SQL
             data_triase_igd.no_rawat no_rawat,
+            bridging_sep.no_sep no_sep,
             reg_periksa.no_rkm_medis no_rkm_medis,
             pasien.nm_pasien nm_pasien,
             penjab.png_jawab png_jawab,
             data_triase_igd.tgl_kunjungan tgl_kunjungan,
             data_triase_igd.cara_masuk cara_masuk,
+            reg_periksa.status_lanjut status_lanjut,
             data_triase_igd.alasan_kedatangan alasan_kedatangan,
             master_triase_macam_kasus.macam_kasus macam_kasus,
             data_triase_igdsekunder.plan plan
@@ -57,6 +61,7 @@ class DataTriaseIgd extends Model
             ->selectRaw($sqlSelect)
             ->join('master_triase_macam_kasus', 'data_triase_igd.kode_kasus', '=', 'master_triase_macam_kasus.kode_kasus')
             ->join('reg_periksa', 'data_triase_igd.no_rawat', '=', 'reg_periksa.no_rawat')
+            ->join('bridging_sep', 'data_triase_igd.no_rawat', '=', 'bridging_sep.no_rawat')
             ->join('pasien', 'reg_periksa.no_rkm_medis', '=', 'pasien.no_rkm_medis')
             ->join('penjab', 'reg_periksa.kd_pj', '=', 'penjab.kd_pj')
             ->join('data_triase_igdsekunder', 'data_triase_igd.no_rawat', '=', 'data_triase_igdsekunder.no_rawat')

--- a/resources/views/livewire/pages/casemix/laporan-triase-igd-zona-hijau.blade.php
+++ b/resources/views/livewire/pages/casemix/laporan-triase-igd-zona-hijau.blade.php
@@ -6,11 +6,13 @@
             <x-table :sortColumns="$sortColumns" sortable zebra hover sticky nowrap>
                 <x-slot name="columns">
                     <x-table.th name="no_rawat" title="No. Rawat" />
+                    <x-table.th name="no_sep" title="No. SEP" />
                     <x-table.th name="no_rkm_medis" title="No. RM" />
                     <x-table.th name="nm_pasien" title="Nama Pasien" />
                     <x-table.th name="png_jawab" title="Jenis Bayar" />
                     <x-table.th name="tgl_kunjungan" title="Tgl. Kunjungan" />
                     <x-table.th name="cara_masuk" title="Cara Masuk" />
+                    <x-table.th name="status_lanjut" title="Status" />
                     <x-table.th name="alasan_kedatangan" title="Alasan Kedatangan" />
                     <x-table.th name="macam_kasus" title="Macam Kasus" />
                     <x-table.th name="plan" title="Zona" />
@@ -19,17 +21,19 @@
                     @forelse ($this->collection as $item)
                         <x-table.tr>
                             <x-table.td>{{ $item->no_rawat }}</x-table.td>
+                            <x-table.td>{{ $item->no_sep }}</x-table.td>
                             <x-table.td>{{ $item->no_rkm_medis }}</x-table.td>
                             <x-table.td>{{ $item->nm_pasien }}</x-table.td>
                             <x-table.td>{{ $item->png_jawab }}</x-table.td>
                             <x-table.td>{{ $item->tgl_kunjungan }}</x-table.td>
                             <x-table.td>{{ $item->cara_masuk }}</x-table.td>
+                            <x-table.td>{{ $item->status_lanjut }}</x-table.td>
                             <x-table.td>{{ $item->alasan_kedatangan }}</x-table.td>
                             <x-table.td>{{ $item->macam_kasus }}</x-table.td>
                             <x-table.td>{{ $item->plan }}</x-table.td>
                         </x-table.tr>
                     @empty
-                        <x-table.tr-empty colspan="9" padding />
+                        <x-table.tr-empty colspan="11" padding />
                     @endforelse
                 </x-slot>
             </x-table>


### PR DESCRIPTION
This pull request enhances the IGD Zona Hijau triage report by adding two new data fields: "No. SEP" and "Status". These fields are now included throughout the data retrieval process, in the report's table display, and in the export functionality. The changes ensure that users can view and search by these additional attributes, improving the report's usefulness and completeness.

**Data Model and Query Enhancements:**

* Updated the `scopeTriaseIgdZonaHijau` method in `DataTriaseIgd.php` to join the `bridging_sep` table and include `no_sep` and `status_lanjut` fields in both the select statement and searchable columns. [[1]](diffhunk://#diff-3c2f9483a23baa413cd7b872674856ae015b888305e09620f6ab13e2e9e6f76cR34-R54) [[2]](diffhunk://#diff-3c2f9483a23baa413cd7b872674856ae015b888305e09620f6ab13e2e9e6f76cR64)

**Report Export and Table Display:**

* Modified the data export (`dataPerSheet`) and column header methods in `LaporanTriaseIgdZonaHijau.php` to include "No. SEP" and "Status" fields. [[1]](diffhunk://#diff-d3473f5be3084eb78cb1a4a083f7a26facb0f8561df419ef84abcdfb95911b87R75-R81) [[2]](diffhunk://#diff-d3473f5be3084eb78cb1a4a083f7a26facb0f8561df419ef84abcdfb95911b87R93-R99)
* Updated the Blade view (`laporan-triase-igd-zona-hijau.blade.php`) to display the new columns in the table header and each row, and adjusted the empty row colspan accordingly. [[1]](diffhunk://#diff-bd68e8f126e7c217503b9ca8943c90cd9816679a0692ad87943286c7a4830694R9-R15) [[2]](diffhunk://#diff-bd68e8f126e7c217503b9ca8943c90cd9816679a0692ad87943286c7a4830694R24-R36)