### PR TITLE
Add No. SEP to lab and radiology reports

### DIFF
--- a/app/Livewire/Pages/Keuangan/LaporanTindakanLab.php
+++ b/app/Livewire/Pages/Keuangan/LaporanTindakanLab.php
@@ -81,6 +81,7 @@ class LaporanTindakanLab extends Component
                 ->cursor()
                 ->map(fn (PeriksaLab $model): array => [
                     'no_rawat'       => $model->no_rawat,
+                    'no_sep'         => $model->no_sep,
                     'no_rkm_medis'   => $model->no_rkm_medis,
                     'nm_pasien'      => $model->nm_pasien,
                     'png_jawab'      => $model->png_jawab,
@@ -104,6 +105,7 @@ class LaporanTindakanLab extends Component
     {
         return [
             'No. Rawat',
+            'No. SEP',
             'No. RM',
             'Pasien',
             'Jenis Bayar',

--- a/app/Livewire/Pages/Keuangan/LaporanTindakanRadiologi.php
+++ b/app/Livewire/Pages/Keuangan/LaporanTindakanRadiologi.php
@@ -76,6 +76,7 @@ class LaporanTindakanRadiologi extends Component
                 ->cursor()
                 ->map(fn (PeriksaRadiologi $model): array => [
                     'no_rawat'          => $model->no_rawat,
+                    'no_sep'            => $model->no_sep,
                     'no_rkm_medis'      => $model->no_rkm_medis,
                     'nm_pasien'         => $model->nm_pasien,
                     'png_jawab'         => $model->png_jawab,
@@ -99,6 +100,7 @@ class LaporanTindakanRadiologi extends Component
     {
         return [
             'No. Rawat',
+            'No. SEP',
             'No. RM',
             'Pasien',
             'Jenis Bayar',

--- a/app/Models/Laboratorium/PeriksaLab.php
+++ b/app/Models/Laboratorium/PeriksaLab.php
@@ -79,7 +79,8 @@ class PeriksaLab extends Model
         }
 
         $sqlSelect = <<<'SQL'
-            periksa_lab.no_rawat no_rawat,
+            periksa_lab.no_rawat,
+            bridging_sep.no_sep,
             reg_periksa.no_rkm_medis,
             pasien.nm_pasien,
             penjab.png_jawab,
@@ -98,7 +99,7 @@ class PeriksaLab extends Model
             SQL;
 
         $this->addSearchConditions([
-            'periksa_lab.no_rawat no_rawat',
+            'periksa_lab.no_rawat',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',
@@ -122,6 +123,7 @@ class PeriksaLab extends Model
             ->leftJoin('penjab', 'reg_periksa.kd_pj', '=', 'penjab.kd_pj')
             ->leftJoin('dokter', 'periksa_lab.kd_dokter', '=', 'dokter.kd_dokter')
             ->leftJoin('jns_perawatan_lab', 'periksa_lab.kd_jenis_prw', '=', 'jns_perawatan_lab.kd_jenis_prw')
+            ->leftJoin('bridging_sep', 'periksa_lab.no_rawat', '=', 'bridging_sep.no_rawat')
             ->whereBetween('periksa_lab.tgl_periksa', [$tglAwal, $tglAkhir]);
     }
 

--- a/app/Models/Radiologi/PeriksaRadiologi.php
+++ b/app/Models/Radiologi/PeriksaRadiologi.php
@@ -47,6 +47,7 @@ class PeriksaRadiologi extends Model
 
         $sqlSelect = <<<'SQL'
             periksa_radiologi.no_rawat,
+            bridging_sep.no_sep,
             reg_periksa.no_rkm_medis,
             pasien.nm_pasien,
             penjab.png_jawab,
@@ -66,6 +67,7 @@ class PeriksaRadiologi extends Model
 
         $this->addSearchConditions([
             'periksa_radiologi.no_rawat',
+            'bridging_sep.no_sep',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',
@@ -82,6 +84,7 @@ class PeriksaRadiologi extends Model
 
         $this->addRawColumns([
             'no_rawat'          => 'periksa_radiologi.no_rawat',
+            'no_sep'            => 'bridging_sep.no_sep',
             'no_rkm_medis'      => 'reg_periksa.no_rkm_medis',
             'nm_pasien'         => 'pasien.nm_pasien',
             'png_jawab'         => 'penjab.png_jawab',
@@ -103,6 +106,7 @@ class PeriksaRadiologi extends Model
             ->selectRaw($sqlSelect)
             ->withCasts(['biaya' => 'float'])
             ->leftJoin('reg_periksa', 'periksa_radiologi.no_rawat', '=', 'reg_periksa.no_rawat')
+            ->leftJoin('bridging_sep', 'periksa_radiologi.no_rawat', '=', 'bridging_sep.no_rawat')
             ->leftJoin('pasien', 'reg_periksa.no_rkm_medis', '=', 'pasien.no_rkm_medis')
             ->leftJoin('petugas', 'periksa_radiologi.nip', '=', 'petugas.nip')
             ->leftJoin('penjab', 'reg_periksa.kd_pj', '=', 'penjab.kd_pj')

--- a/resources/views/livewire/pages/keuangan/laporan-tindakan-lab.blade.php
+++ b/resources/views/livewire/pages/keuangan/laporan-tindakan-lab.blade.php
@@ -6,6 +6,7 @@
             <x-table :sortColumns="$sortColumns" style="width: 150rem" sortable zebra hover sticky nowrap>
                 <x-slot name="columns">
                     <x-table.th style="width: 20ch" name="no_rawat" title="No. Rawat" />
+                    <x-table.th style="width: 12ch" name="no_sep" title="No. SEP" />
                     <x-table.th style="width: 12ch" name="no_rkm_medis" title="No. RM" />
                     <x-table.th style="width: 42ch" name="nm_pasien" title="Pasien" />
                     <x-table.th style="width: 20ch" name="png_jawab" title="Jenis Bayar" />
@@ -26,6 +27,7 @@
                     @forelse ($this->dataLaporanTindakanLab as $item)
                         <x-table.tr>
                             <x-table.td>{{ $item->no_rawat }}</x-table.td>
+                            <x-table.td>{{ $item->no_sep }}</x-table.td>
                             <x-table.td>
                                 {{ $item->no_rkm_medis }}
                             </x-table.td>
@@ -57,7 +59,7 @@
                             <x-table.td>{{ $item->nm_dokter }}</x-table.td>
                         </x-table.tr>
                     @empty
-                        <x-table.tr-empty colspan="16" padding />
+                        <x-table.tr-empty colspan="17" padding />
                     @endforelse
                 </x-slot>
             </x-table>

--- a/resources/views/livewire/pages/keuangan/laporan-tindakan-radiologi.blade.php
+++ b/resources/views/livewire/pages/keuangan/laporan-tindakan-radiologi.blade.php
@@ -6,6 +6,7 @@
             <x-table :sortColumns="$sortColumns" style="width: 185rem" sortable zebra hover sticky nowrap>
                 <x-slot name="columns">
                     <x-table.th style="width: 20ch" name="no_rawat" title="No. Rawat" />
+                    <x-table.th style="width: 20ch" name="no_sep" title="No. SEP" />
                     <x-table.th style="width: 12ch" name="no_rkm_medis" title="No. RM" />
                     <x-table.th style="width: 42ch" name="nm_pasien" title="Pasien" />
                     <x-table.th style="width: 20ch" name="png_jawab" title="Jenis Bayar" />
@@ -26,6 +27,7 @@
                     @forelse ($this->dataLaporanTindakanRadiologi as $item)
                         <x-table.tr>
                             <x-table.td>{{ $item->no_rawat }}</x-table.td>
+                            <x-table.td>{{ $item->no_sep }}</x-table.td>
                             <x-table.td>
                                 {{ $item->no_rkm_medis }}
                             </x-table.td>
@@ -59,7 +61,7 @@
                             </x-table.td>
                         </x-table.tr>
                     @empty
-                        <x-table.tr-empty colspan="16" padding />
+                        <x-table.tr-empty colspan="17" padding />
                     @endforelse
                 </x-slot>
             </x-table>


### PR DESCRIPTION
This commit adds the 'No. SEP' field to both lab and radiology financial report pages, updates the corresponding models to join and select the SEP number from the bridging_sep table, and modifies the views to display the new column. This provides more comprehensive reporting by including SEP information for each record.