### PR TITLE
Update no_sep selection logic in lab and radiology models

### DIFF
--- a/app/Models/Laboratorium/PeriksaLab.php
+++ b/app/Models/Laboratorium/PeriksaLab.php
@@ -80,7 +80,7 @@ class PeriksaLab extends Model
 
         $sqlSelect = <<<'SQL'
             periksa_lab.no_rawat,
-            bridging_sep.no_sep,
+            coalesce(case when periksa_lab.status = 'Ranap' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = '1' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = '2' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat order by bridging_sep.tglsep desc limit 1)) as no_sep,
             reg_periksa.no_rkm_medis,
             pasien.nm_pasien,
             penjab.png_jawab,
@@ -100,6 +100,7 @@ class PeriksaLab extends Model
 
         $this->addSearchConditions([
             'periksa_lab.no_rawat',
+            'coalesce(case when periksa_lab.status = \'Ranap\' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = \'1\' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = \'2\' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat order by bridging_sep.tglsep desc limit 1))',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',

--- a/app/Models/Laboratorium/PeriksaLab.php
+++ b/app/Models/Laboratorium/PeriksaLab.php
@@ -4,6 +4,8 @@ namespace App\Models\Laboratorium;
 
 use App\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Facades\DB;
 use Reedware\LaravelCompositeRelations\CompositeBelongsTo;
 use Reedware\LaravelCompositeRelations\HasCompositeRelations;
 
@@ -80,7 +82,7 @@ class PeriksaLab extends Model
 
         $sqlSelect = <<<'SQL'
             periksa_lab.no_rawat,
-            coalesce(case when periksa_lab.status = 'Ranap' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = '1' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = '2' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat order by bridging_sep.tglsep desc limit 1)) as no_sep,
+            bridging_sep.no_sep,
             reg_periksa.no_rkm_medis,
             pasien.nm_pasien,
             penjab.png_jawab,
@@ -100,7 +102,7 @@ class PeriksaLab extends Model
 
         $this->addSearchConditions([
             'periksa_lab.no_rawat',
-            'coalesce(case when periksa_lab.status = \'Ranap\' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = \'1\' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat and bridging_sep.jnspelayanan = \'2\' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_lab.no_rawat order by bridging_sep.tglsep desc limit 1))',
+            'bridging_sep.no_sep',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',
@@ -119,12 +121,15 @@ class PeriksaLab extends Model
             ->selectRaw($sqlSelect)
             ->withCasts(['biaya' => 'float'])
             ->leftJoin('reg_periksa', 'periksa_lab.no_rawat', '=', 'reg_periksa.no_rawat')
+            ->leftJoin('bridging_sep', fn (JoinClause $join) => $join
+                ->on('reg_periksa.no_rawat', '=', 'bridging_sep.no_rawat')
+                ->on('reg_periksa.status_lanjut', '=', DB::raw('(if(bridging_sep.jnspelayanan = "1", "Ranap", "Ralan"))'))
+            )
             ->leftJoin('pasien', 'reg_periksa.no_rkm_medis', '=', 'pasien.no_rkm_medis')
             ->leftJoin('petugas', 'periksa_lab.nip', '=', 'petugas.nip')
             ->leftJoin('penjab', 'reg_periksa.kd_pj', '=', 'penjab.kd_pj')
             ->leftJoin('dokter', 'periksa_lab.kd_dokter', '=', 'dokter.kd_dokter')
             ->leftJoin('jns_perawatan_lab', 'periksa_lab.kd_jenis_prw', '=', 'jns_perawatan_lab.kd_jenis_prw')
-            ->leftJoin('bridging_sep', 'periksa_lab.no_rawat', '=', 'bridging_sep.no_rawat')
             ->whereBetween('periksa_lab.tgl_periksa', [$tglAwal, $tglAkhir]);
     }
 

--- a/app/Models/Radiologi/PeriksaRadiologi.php
+++ b/app/Models/Radiologi/PeriksaRadiologi.php
@@ -47,7 +47,7 @@ class PeriksaRadiologi extends Model
 
         $sqlSelect = <<<'SQL'
             periksa_radiologi.no_rawat,
-            coalesce(case when periksa_radiologi.status = 'Ranap' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = '1' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = '2' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat order by bridging_sep.tglsep desc limit 1)) as no_sep,
+            bridging_sep.no_sep,
             reg_periksa.no_rkm_medis,
             pasien.nm_pasien,
             penjab.png_jawab,
@@ -67,7 +67,7 @@ class PeriksaRadiologi extends Model
 
         $this->addSearchConditions([
             'periksa_radiologi.no_rawat',
-            'coalesce(case when periksa_radiologi.status = \'Ranap\' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'1\' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'2\' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat order by bridging_sep.tglsep desc limit 1))',
+            'bridging_sep.no_sep',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',
@@ -84,7 +84,7 @@ class PeriksaRadiologi extends Model
 
         $this->addRawColumns([
             'no_rawat'          => 'periksa_radiologi.no_rawat',
-            'no_sep'            =>  DB::raw('coalesce(case when periksa_radiologi.status = \'Ranap\' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'1\' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'2\' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat order by bridging_sep.tglsep desc limit 1))'),
+            'no_sep'            =>  'bridging_sep.no_sep',
             'no_rkm_medis'      => 'reg_periksa.no_rkm_medis',
             'nm_pasien'         => 'pasien.nm_pasien',
             'png_jawab'         => 'penjab.png_jawab',
@@ -106,7 +106,10 @@ class PeriksaRadiologi extends Model
             ->selectRaw($sqlSelect)
             ->withCasts(['biaya' => 'float'])
             ->leftJoin('reg_periksa', 'periksa_radiologi.no_rawat', '=', 'reg_periksa.no_rawat')
-            ->leftJoin('bridging_sep', 'periksa_radiologi.no_rawat', '=', 'bridging_sep.no_rawat')
+            ->leftJoin('bridging_sep', fn (JoinClause $join) => $join
+                ->on('reg_periksa.no_rawat', '=', 'bridging_sep.no_rawat')
+                ->on('reg_periksa.status_lanjut', '=', DB::raw('(if(bridging_sep.jnspelayanan = "1", "Ranap", "Ralan"))'))
+            )
             ->leftJoin('pasien', 'reg_periksa.no_rkm_medis', '=', 'pasien.no_rkm_medis')
             ->leftJoin('petugas', 'periksa_radiologi.nip', '=', 'petugas.nip')
             ->leftJoin('penjab', 'reg_periksa.kd_pj', '=', 'penjab.kd_pj')

--- a/app/Models/Radiologi/PeriksaRadiologi.php
+++ b/app/Models/Radiologi/PeriksaRadiologi.php
@@ -47,7 +47,7 @@ class PeriksaRadiologi extends Model
 
         $sqlSelect = <<<'SQL'
             periksa_radiologi.no_rawat,
-            bridging_sep.no_sep,
+            coalesce(case when periksa_radiologi.status = 'Ranap' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = '1' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = '2' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat order by bridging_sep.tglsep desc limit 1)) as no_sep,
             reg_periksa.no_rkm_medis,
             pasien.nm_pasien,
             penjab.png_jawab,
@@ -67,7 +67,7 @@ class PeriksaRadiologi extends Model
 
         $this->addSearchConditions([
             'periksa_radiologi.no_rawat',
-            'bridging_sep.no_sep',
+            'coalesce(case when periksa_radiologi.status = \'Ranap\' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'1\' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'2\' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat order by bridging_sep.tglsep desc limit 1))',
             'reg_periksa.no_rkm_medis',
             'pasien.nm_pasien',
             'penjab.png_jawab',
@@ -84,7 +84,7 @@ class PeriksaRadiologi extends Model
 
         $this->addRawColumns([
             'no_rawat'          => 'periksa_radiologi.no_rawat',
-            'no_sep'            => 'bridging_sep.no_sep',
+            'no_sep'            =>  DB::raw('coalesce(case when periksa_radiologi.status = \'Ranap\' then (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'1\' order by bridging_sep.tglsep desc limit 1) else (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat and bridging_sep.jnspelayanan = \'2\' order by bridging_sep.tglsep desc limit 1) end, (select bridging_sep.no_sep from bridging_sep where bridging_sep.no_rawat = periksa_radiologi.no_rawat order by bridging_sep.tglsep desc limit 1))'),
             'no_rkm_medis'      => 'reg_periksa.no_rkm_medis',
             'nm_pasien'         => 'pasien.nm_pasien',
             'png_jawab'         => 'penjab.png_jawab',


### PR DESCRIPTION
Replaced direct bridging_sep.no_sep references with a COALESCE SQL expression that selects no_sep based on patient status and jnspelayanan, improving accuracy for both PeriksaLab and PeriksaRadiologi models. Also updated search conditions and raw columns to use the new logic.