### PR TITLE
fix: duplicate row on hpp pembelian terakhir

### DIFF
--- a/app/Livewire/Pages/Farmasi/HppPembelianTerakhir.php
+++ b/app/Livewire/Pages/Farmasi/HppPembelianTerakhir.php
@@ -9,7 +9,6 @@ use App\Livewire\Concerns\FlashComponent;
 use App\Livewire\Concerns\LiveTable;
 use App\Livewire\Concerns\MenuTracker;
 use App\Models\Farmasi\Inventaris\GudangObat;
-use App\Models\Farmasi\PenerimaanObatDetail;
 use App\View\Components\BaseLayout;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
@@ -41,7 +40,7 @@ class HppPembelianTerakhir extends Component
 
     public function getCollectionProperty()
     {
-        return $this->isDeferred ? [] : PenerimaanObatDetail::query()
+        return $this->isDeferred ? [] : GudangObat::query()
             ->hppPembelianTerakhir($this->kodeBangsal)
             ->sortWithColumns($this->sortColumns)
             ->search($this->cari)
@@ -69,14 +68,14 @@ class HppPembelianTerakhir extends Component
     protected function dataPerSheet(): array
     {
         return [
-            fn () => PenerimaanObatDetail::query()
+            fn () => GudangObat::query()
                 ->hppPembelianTerakhir($this->kodeBangsal)
                 ->search($this->cari)
                 ->sortWithColumns($this->sortColumns)
                 ->cursor()
-                ->map(fn (PenerimaanObatDetail $model): array => [
-                    'no_faktur'         => $model->no_faktur,
-                    'tgl_pesan'         => $model->tgl_pesan,
+                ->map(fn (GudangObat $model): array => [
+                    'no_faktur'         => $model->no_faktur ?? '-',
+                    'tgl_pesan'         => $model->tgl_pesan ?? '-',
                     'nm_bangsal'        => $model->nm_bangsal,
                     'kode_brng'         => $model->kode_brng,
                     'nama_brng'         => $model->nama_brng,
@@ -84,7 +83,7 @@ class HppPembelianTerakhir extends Component
                     'isi'               => $model->isi,
                     'kode_sat'          => $model->kode_sat,
                     'kapasitas'         => $model->kapasitas,
-                    'stok'              => round(floatval($model->stok), 2),
+                    'stok'              => $model->stok,
                     'h_pesan'           => $model->h_pesan,
                     'dis'               => $model->dis,
                     'harga_satuan'      => $model->harga_satuan,

--- a/app/Models/Farmasi/Inventaris/GudangObat.php
+++ b/app/Models/Farmasi/Inventaris/GudangObat.php
@@ -152,4 +152,87 @@ class GudangObat extends Model
                 ->orWhere('pemberian_obat_3hari.jumlah', '>', 0)
                 ->orWhere('pemberian_obat_6hari.jumlah', '>', 0));
     }
+
+    public function scopeHppPembelianTerakhir(Builder $query, string $kodeBangsal = '-'): Builder
+    {
+        $hPesan = 'COALESCE(lp.h_pesan, databarang.h_beli)';
+        $dis = 'COALESCE(lp.dis, 0)';
+        $hargaKecil = <<<'SQL'
+            COALESCE(
+                lp.h_pesan / NULLIF(lp.jumlah2 / NULLIF(lp.jumlah, 0), 0),
+                databarang.h_beli / NULLIF(databarang.isi, 0)
+            )
+            SQL;
+        $hpp = "round(($hargaKecil * (1 - ($dis / 100))) * 1.11, 2)";
+
+        $lastOrder = fn ($query) => $query
+            ->selectRaw('kode_brng, no_faktur_terakhir')
+            ->fromSub(
+                fn ($inner) => $inner
+                    ->selectRaw('
+                        d2.kode_brng,
+                        d2.no_faktur AS no_faktur_terakhir,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY d2.kode_brng
+                            ORDER BY p2.tgl_pesan DESC, d2.h_pesan DESC
+                        ) AS rn
+                    ')
+                    ->from('detailpesan as d2')
+                    ->join('pemesanan as p2', 'd2.no_faktur', '=', 'p2.no_faktur'),
+                'ranked'
+            )
+            ->where('rn', 1);
+
+        $sqlSelect = <<<SQL
+            bangsal.nm_bangsal,
+            databarang.kode_brng,
+            databarang.nama_brng,
+            databarang.kode_satbesar,
+            databarang.isi,
+            databarang.kode_sat,
+            databarang.kapasitas,
+            gudangbarang.stok,
+            lp.no_faktur,
+            pm.tgl_pesan,
+            $hPesan h_pesan,
+            $dis dis,
+            round($hargaKecil, 2) harga_satuan,
+            $hpp hpp
+        SQL;
+
+        $this->addSearchConditions([
+            'x.nm_bangsal',
+            'x.kode_brng',
+            'x.nama_brng',
+        ]);
+
+        $this->addRawColumns([
+            'total_nilai_stok' => DB::raw('ROUND(x.hpp * x.stok, 2)'),
+        ]);
+
+        return $query
+            ->fromSub(
+                fn ($sub) => $sub
+                    ->selectRaw($sqlSelect)
+                    ->from('gudangbarang')
+                    ->join('databarang', 'gudangbarang.kode_brng', '=', 'databarang.kode_brng')
+                    ->join('bangsal', 'gudangbarang.kd_bangsal', '=', 'bangsal.kd_bangsal')
+                    ->leftJoinSub($lastOrder, 'last_order', 'last_order.kode_brng', '=', 'gudangbarang.kode_brng')
+                    ->leftJoinSub(
+                        fn ($q) => $q
+                            ->selectRaw('no_faktur, kode_brng, MAX(h_pesan) as h_pesan, MAX(dis) as dis, MAX(jumlah) as jumlah, MAX(jumlah2) as jumlah2')
+                            ->from('detailpesan')
+                            ->groupBy('no_faktur', 'kode_brng'),
+                        'lp',
+                        fn (JoinClause $join) => $join
+                            ->on('lp.kode_brng', '=', 'gudangbarang.kode_brng')
+                            ->on('lp.no_faktur', '=', 'last_order.no_faktur_terakhir')
+                    )
+                    ->leftJoin('pemesanan as pm', 'pm.no_faktur', '=', 'lp.no_faktur')
+                    ->when($kodeBangsal !== '-', fn ($q) => $q->where('bangsal.kd_bangsal', $kodeBangsal)),
+                'x'
+            )
+            ->selectRaw('x.*, ROUND(x.hpp * x.stok, 2) as total_nilai_stok')
+            ->orderBy('x.kode_brng');
+    }
 }

--- a/app/Models/Farmasi/PenerimaanObatDetail.php
+++ b/app/Models/Farmasi/PenerimaanObatDetail.php
@@ -3,7 +3,6 @@
 namespace App\Models\Farmasi;
 
 use App\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
 
 class PenerimaanObatDetail extends Model
 {
@@ -18,75 +17,4 @@ class PenerimaanObatDetail extends Model
     public $incrementing = false;
 
     public $timestamps = false;
-
-    public function scopeHppPembelianTerakhir(Builder $query, $kodeBangsal = ''): Builder
-    {
-        $hargaKecil = 'detailpesan.h_pesan / NULLIF(detailpesan.jumlah2 / NULLIF(detailpesan.jumlah, 0), 0)';
-        $setelahDiskon = "($hargaKecil * (1 - (detailpesan.dis / 100)))";
-        $hpp = "round(($setelahDiskon * 1.11), 2)";
-
-        $this->addSearchConditions([
-            'x.no_faktur',
-            'x.kode_brng',
-            'x.nama_brng',
-            'x.nm_bangsal',
-        ]);
-
-        return $query->fromSub(function ($sub) use ($hargaKecil, $hpp, $kodeBangsal) {
-
-            $sub->selectRaw("
-                    detailpesan.no_faktur,
-                    pemesanan.tgl_pesan,
-                    bangsal.nm_bangsal,
-                    detailpesan.kode_brng,
-                    databarang.nama_brng,
-                    databarang.kode_satbesar,
-                    databarang.isi,
-                    databarang.kode_sat,
-                    databarang.kapasitas,
-                    gudangbarang.stok,
-                    detailpesan.h_pesan,
-                    detailpesan.dis,
-                    round($hargaKecil, 2) as harga_satuan,
-                    $hpp as hpp
-                ")
-                ->from('detailpesan')
-                ->join('pemesanan', 'detailpesan.no_faktur', '=', 'pemesanan.no_faktur')
-                ->join('databarang', 'detailpesan.kode_brng', '=', 'databarang.kode_brng')
-                ->join('gudangbarang', 'detailpesan.kode_brng', '=', 'gudangbarang.kode_brng')
-                ->join('bangsal', 'gudangbarang.kd_bangsal', '=', 'bangsal.kd_bangsal')
-                ->joinSub(
-                    function ($query) {
-                        $query->selectRaw('kode_brng, tgl_terakhir, h_pesan_terakhir')
-                            ->fromSub(function ($inner) {
-                                $inner->selectRaw('
-                                        d2.kode_brng,
-                                        p2.tgl_pesan AS tgl_terakhir,
-                                        d2.h_pesan AS h_pesan_terakhir,
-                                        ROW_NUMBER() OVER (
-                                            PARTITION BY d2.kode_brng
-                                            ORDER BY p2.tgl_pesan DESC, d2.h_pesan DESC
-                                        ) AS rn
-                                    ')
-                                    ->from('detailpesan as d2')
-                                    ->join('pemesanan as p2', 'd2.no_faktur', '=', 'p2.no_faktur');
-                            }, 'ranked')
-                            ->where('rn', 1);
-                    },
-                    'last_order',
-                    function ($join) {
-                        $join->on('detailpesan.kode_brng', '=', 'last_order.kode_brng')
-                            ->on('pemesanan.tgl_pesan', '=', 'last_order.tgl_terakhir')
-                            ->on('detailpesan.h_pesan', '=', 'last_order.h_pesan_terakhir');
-                    }
-                )->when($kodeBangsal !== '-', function ($q) use ($kodeBangsal) {
-                    $q->where('bangsal.kd_bangsal', $kodeBangsal);
-                });
-        }, 'x')
-            ->selectRaw('
-            x.*,
-            ROUND(x.hpp * x.stok, 2) as total_nilai_stok
-        ')
-            ->orderBy('x.kode_brng', 'asc');
-    }
 }

--- a/resources/views/livewire/pages/farmasi/hpp-pembelian-terakhir.blade.php
+++ b/resources/views/livewire/pages/farmasi/hpp-pembelian-terakhir.blade.php
@@ -36,8 +36,8 @@
                 <x-slot name="body">
                     @forelse ($this->collection as $item)
                         <x-table.tr>
-                            <x-table.td>{{ $item->no_faktur }}</x-table.td>
-                            <x-table.td>{{ $item->tgl_pesan }}</x-table.td>
+                            <x-table.td>{{ $item->no_faktur ?? '-' }}</x-table.td>
+                            <x-table.td>{{ $item->tgl_pesan ?? '-' }}</x-table.td>
                             <x-table.td>{{ $item->nm_bangsal }}</x-table.td>
                             <x-table.td>{{ $item->kode_brng }}</x-table.td>
                             <x-table.td>{{ $item->nama_brng }}</x-table.td>


### PR DESCRIPTION
**Bug fixes:**
- Duplikat data akibat multiple faktur di tanggal yang sama → solusi `ROW_NUMBER() OVER (PARTITION BY kode_brng ORDER BY tgl_pesan DESC, h_pesan DESC)`
- Duplikat akibat `kode_brng` yang sama dalam satu faktur di `detailpesan` → solusi `GROUP BY no_faktur, kode_brng` pada subquery `lp`

**Fitur baru:**
- Fallback ke `databarang.h_beli` untuk barang yang belum pernah ada penerimaan

**Refactoring:**
- Scope dipindah dari `PenerimaanObatDetail` ke `GudangObat` yang lebih semantik