### PR TITLE
fix(farmasi): aggregate quantities in PO comparison

### DIFF
--- a/app/Models/Farmasi/Inventaris/SuratPemesananObat.php
+++ b/app/Models/Farmasi/Inventaris/SuratPemesananObat.php
@@ -48,10 +48,11 @@ class SuratPemesananObat extends Model
             SQL;
 
         $queryPOYangDatang = PenerimaanObat::query()
-            ->selectRaw('pemesanan.no_order, pemesanan.tgl_pesan, detailpesan.kode_brng, detailpesan.jumlah2 as jumlah, pemesanan.kode_suplier, datasuplier.nama_suplier')
+            ->selectRaw('pemesanan.no_order, detailpesan.kode_brng, sum(detailpesan.jumlah2) as jumlah, min(datasuplier.nama_suplier) as nama_suplier')
             ->join('datasuplier', 'pemesanan.kode_suplier', '=', 'datasuplier.kode_suplier')
             ->join('detailpesan', 'pemesanan.no_faktur', '=', 'detailpesan.no_faktur')
-            ->join('databarang', 'detailpesan.kode_brng', '=', 'databarang.kode_brng');
+            ->join('databarang', 'detailpesan.kode_brng', '=', 'databarang.kode_brng')
+            ->groupBy('pemesanan.no_order', 'detailpesan.kode_brng');
 
         $this->addSearchConditions([
             'surat_pemesanan_medis.no_pemesanan',


### PR DESCRIPTION
  Laporan Perbaikan: Duplikasi Baris pada Perbandingan Barang PO

  1. Masalah yang Diidentifikasi:
  Ditemukan adanya baris duplikat pada laporan "Ringkasan Perbandingan Barang PO Farmasi". Hal ini terjadi ketika satu nomor pesanan (no_order /
  no_pemesanan) memiliki lebih dari satu nomor faktur (no_faktur) karena barang datang secara bertahap. Sistem sebelumnya menampilkan setiap faktur
  sebagai baris terpisah, yang menyebabkan selisih perhitungan menjadi tidak akurat.

  2. Perubahan yang Dilakukan:
  Saya telah memperbarui logika query pada model App\Models\Farmasi\Inventaris\SuratPemesananObat.php dalam fungsi scopePerbandinganPemesananObatPO:

   * Agregasi Jumlah: Mengubah subquery queryPOYangDatang untuk menggunakan fungsi SUM(detailpesan.jumlah2). Ini memastikan bahwa semua barang yang
     datang dari berbagai faktur untuk pesanan yang sama akan dijumlahkan menjadi satu total.
   * Pengelompokan (Group By): Menambahkan klausa groupBy('pemesanan.no_order', 'detailpesan.kode_brng') agar data dikonsolidasikan berdasarkan
     nomor pesanan dan kode barang.
   * Kompatibilitas SQL Strict Mode: Menggunakan fungsi min(datasuplier.nama_suplier) untuk mengambil nama supplier guna memenuhi aturan
     ONLY_FULL_GROUP_BY pada MySQL, sehingga query tetap berjalan stabil di berbagai konfigurasi server.
   * Pembersihan Query: Menghapus kolom yang tidak relevan (seperti tgl_pesan di dalam subquery) untuk meningkatkan efisiensi dan akurasi
     pengelompokan.