### PR TITLE
fix(export): resolve double slash in excel export file path

### DIFF
--- a/app/Jobs/ExcelExportJob.php
+++ b/app/Jobs/ExcelExportJob.php
@@ -55,7 +55,7 @@ abstract class ExcelExportJob implements ShouldQueue
             : $dataSheets[$firstSheet];
         $firstData = is_callable($firstData) ? $firstData() : $firstData;
 
-        $excel = ExcelExport::make($filename, $firstSheet)
+        $excel = ExcelExport::make($filename, $firstSheet, 'excel')
             ->setPageHeaders($this->pageHeaders());
 
         if (Arr::isAssoc($columnHeaders)) {


### PR DESCRIPTION
PR ini memperbaiki masalah munculnya karakter double slash (//) pada file path hasil ekspor Excel (misal:
  excel//filename.xlsx). Masalah ini ditemukan pada modul Laba Rugi Rekening dan modul lain yang menggunakan trait
  ExcelExportable.

  🛠 Jenis Perubahan
   - [x] Bug fix (perbaikan kode yang memecahkan masalah double slash pada path file)

  🔍 Akar Masalah (Root Cause)
  Masalah berasal dari redundansi karakter pemisah path (/) pada library rizky92/xlswriter-for-laravel:
   1. Metode ExcelExport::make() memiliki nilai default $basePath = 'excel/' (sudah termasuk slash di akhir).
   2. Metode internal save() dan export() pada library tersebut melakukan penggabungan path secara manual:
      $this->basePath . '/' . $this->filename.
   3. Hasilnya, path yang terbentuk menjadi excel/ + / + filename.xlsx => excel//filename.xlsx.

  💡 Solusi
  Melakukan override pada parameter basePath saat inisialisasi ExcelExport::make() dengan mengirimkan string 'excel'
  (tanpa trailing slash). Dengan demikian, penggabungan path oleh library akan menghasilkan garing tunggal yang valid
  (excel/filename.xlsx).

  Perubahan diterapkan pada:
   1. app/Jobs/ExcelExportJob.php: Memperbaiki path pada proses ekspor via antrean (queue) yang dikirim melalui
      notifikasi.