### PR TITLE
Sanitize Excel export values for invalid Unicode characters

### DIFF
--- a/app/Livewire/Concerns/ExcelExportable.php
+++ b/app/Livewire/Concerns/ExcelExportable.php
@@ -61,64 +61,6 @@ trait ExcelExportable
         return $dataSheets;
     }
 
-    /**
-     * @param mixed $value
-     * @return mixed
-     */
-    protected function sanitizeExcelValue($value)
-    {
-        if (! is_string($value)) {
-            return $value;
-        }
-
-        $value = str_replace(
-            [
-                '–', // en dash
-                '—', // em dash
-                '‘',
-                '’',
-                '“',
-                '”',
-            ],
-            [
-                '-',
-                '-',
-                "'",
-                "'",
-                '"',
-                '"',
-            ],
-            $value
-        );
-
-        $value = preg_replace(
-            '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u',
-            '',
-            $value
-        );
-
-        return trim($value);
-    }
-
-    /**
-     * @param mixed $data
-     * @return mixed
-     */
-    protected function sanitizeExcelData($data)
-    {
-        if (is_array($data)) {
-            return array_map([$this, 'sanitizeExcelData'], $data);
-        }
-
-        if ($data instanceof Collection || $data instanceof LazyCollection) {
-            return $data->map(function ($row) {
-                return $this->sanitizeExcelData($row);
-            });
-        }
-
-        return $this->sanitizeExcelValue($data);
-    }
-
     public function exportToExcel(): void
     {
         $this->emit('flash.info', 'Proses ekspor laporan dimulai! Silahkan tunggu beberapa saat. Mohon untuk tidak menutup halaman agar proses ekspor dapat berlanjut.');
@@ -147,8 +89,6 @@ trait ExcelExportable
 
         $firstData = is_callable($firstData) ? $firstData() : $firstData;
 
-        $firstData = $this->sanitizeExcelData($firstData);
-
         File::ensureDirectoryExists(storage_path('app/public/excel'));
 
         $excel = ExcelExport::make($filename, $firstSheet)
@@ -166,9 +106,6 @@ trait ExcelExportable
 
         foreach ($dataSheets as $sheet => $data) {
             $data = is_callable($data) ? $data() : $data;
-
-            $data = $this->sanitizeExcelData($data);
-
             $excel->addSheet($sheet);
 
             if (Arr::isAssoc($columnHeaders)) {

--- a/app/Livewire/Concerns/ExcelExportable.php
+++ b/app/Livewire/Concerns/ExcelExportable.php
@@ -61,6 +61,64 @@ trait ExcelExportable
         return $dataSheets;
     }
 
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function sanitizeExcelValue($value)
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        $value = str_replace(
+            [
+                '–', // en dash
+                '—', // em dash
+                '‘',
+                '’',
+                '“',
+                '”',
+            ],
+            [
+                '-',
+                '-',
+                "'",
+                "'",
+                '"',
+                '"',
+            ],
+            $value
+        );
+
+        $value = preg_replace(
+            '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u',
+            '',
+            $value
+        );
+
+        return trim($value);
+    }
+
+    /**
+     * @param mixed $data
+     * @return mixed
+     */
+    protected function sanitizeExcelData($data)
+    {
+        if (is_array($data)) {
+            return array_map([$this, 'sanitizeExcelData'], $data);
+        }
+
+        if ($data instanceof Collection || $data instanceof LazyCollection) {
+            return $data->map(function ($row) {
+                return $this->sanitizeExcelData($row);
+            });
+        }
+
+        return $this->sanitizeExcelValue($data);
+    }
+
     public function exportToExcel(): void
     {
         $this->emit('flash.info', 'Proses ekspor laporan dimulai! Silahkan tunggu beberapa saat. Mohon untuk tidak menutup halaman agar proses ekspor dapat berlanjut.');
@@ -89,6 +147,8 @@ trait ExcelExportable
 
         $firstData = is_callable($firstData) ? $firstData() : $firstData;
 
+        $firstData = $this->sanitizeExcelData($firstData);
+
         File::ensureDirectoryExists(storage_path('app/public/excel'));
 
         $excel = ExcelExport::make($filename, $firstSheet)
@@ -106,6 +166,9 @@ trait ExcelExportable
 
         foreach ($dataSheets as $sheet => $data) {
             $data = is_callable($data) ? $data() : $data;
+
+            $data = $this->sanitizeExcelData($data);
+
             $excel->addSheet($sheet);
 
             if (Arr::isAssoc($columnHeaders)) {

--- a/app/Livewire/Pages/Keuangan/TarifRadiologi.php
+++ b/app/Livewire/Pages/Keuangan/TarifRadiologi.php
@@ -10,6 +10,7 @@ use App\Livewire\Concerns\LiveTable;
 use App\Livewire\Concerns\MenuTracker;
 use App\Models\Keuangan\JenisPerawatanRadiologi;
 use App\View\Components\BaseLayout;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -57,18 +58,18 @@ class TarifRadiologi extends Component
                 ->search($this->cari)
                 ->cursor()
                 ->map(fn (JenisPerawatanRadiologi $model): array => [
-                    'kd_jenis_prw'              => $model->kd_jenis_prw,
-                    'nm_perawatan'              => $model->nm_perawatan,
-                    'bagian_rs'                 => $model->bagian_rs,
-                    'bhp'                       => $model->bhp,
-                    'tarif_perujuk'             => $model->tarif_perujuk,
-                    'tarif_tindakan_dokter'     => $model->tarif_tindakan_dokter,
-                    'tarif_tindakan_petugas'    => $model->tarif_tindakan_petugas,
-                    'kso'                       => $model->kso,
-                    'menejemen'                 => $model->menejemen,
-                    'total_byr'                 => $model->total_byr,
-                    'png_jawab'                 => $model->png_jawab,
-                    'kelas'                     => $model->kelas,
+                    Str::transliterate($model->kd_jenis_prw),
+                    Str::transliterate($model->nm_perawatan),
+                    Str::transliterate($model->bagian_rs),
+                    Str::transliterate($model->bhp),
+                    Str::transliterate($model->tarif_perujuk),
+                    Str::transliterate($model->tarif_tindakan_dokter),
+                    Str::transliterate($model->tarif_tindakan_petugas),
+                    Str::transliterate($model->kso),
+                    Str::transliterate($model->menejemen),
+                    Str::transliterate($model->total_byr),
+                    Str::transliterate($model->png_jawab),
+                    Str::transliterate($model->kelas),
                 ]),
         ];
     }


### PR DESCRIPTION
Perubahan ini menambahkan proses sanitasi otomatis pada data export Excel untuk mencegah file .xlsx corrupt akibat karakter Unicode khusus dari data legacy SIMRS atau hasil copy-paste.

Perubahan:
- Menambahkan recursive sanitizer untuk data export Excel
- Menormalisasi karakter typography khusus:
  - en dash (–)
  - em dash (—)
  - smart quotes (‘ ’ “ ”)
- Menghapus karakter kontrol XML yang tidak valid untuk kompatibilitas XLSX
- Menerapkan sanitasi otomatis sebelum data ditulis ke file Excel
- Meningkatkan kompatibilitas dengan Microsoft Excel dan parser spreadsheet lainnya
- Mencegah masalah kolom/header hilang akibat malformed XML pada file XLSX hasil export