### PR TITLE
Optimize Excel export by consolidating event emissions

### DIFF
--- a/app/Livewire/Concerns/ExcelExportable.php
+++ b/app/Livewire/Concerns/ExcelExportable.php
@@ -20,14 +20,6 @@ trait ExcelExportable
         '\\', '/', '?', '*', ':', '[', ']',
     ];
 
-    public function initializeExcelExportable(): void
-    {
-        $this->listeners = array_merge($this->listeners, [
-            'exportToExcel',
-            'beginExcelExport',
-        ]);
-    }
-
     /**
      * @return array<array-key, (\Closure(): \Illuminate\Database\Eloquent\Collection|Collection|LazyCollection|array)|Collection|Collection|array>
      */
@@ -61,11 +53,13 @@ trait ExcelExportable
         return $dataSheets;
     }
 
-    public function exportToExcel(): void
+    public function exportToExcel(): ?StreamedResponse
     {
-        $this->emit('flash.info', 'Proses ekspor laporan dimulai! Silahkan tunggu beberapa saat. Mohon untuk tidak menutup halaman agar proses ekspor dapat berlanjut.');
+        if (method_exists($this, 'flashInfo')) {
+            $this->flashInfo('Proses ekspor laporan dimulai! Silahkan tunggu beberapa saat. Mohon untuk tidak menutup halaman agar proses ekspor dapat berlanjut.');
+        }
 
-        $this->emit('beginExcelExport');
+        return $this->beginExcelExport();
     }
 
     public function beginExcelExport(): ?StreamedResponse


### PR DESCRIPTION
Di halaman laporan statistik (dan seluruh menu yang memakai trait `ExcelExportable`), satu klik tombol "Export ke Excel" memicu lebih dari satu request Livewire berurutan ("waterfall"). Setiap request me-render ulang halaman secara penuh, sehingga query laporan yang berat dieksekusi berulang kali untuk data yang sama.

PR #151 sebelumnya sudah menunda eksekusi query ekspor via closure (`dataPerSheet()`), tetapi tidak menyentuh rantai event itu sendiri, sehingga masalah tetap terjadi.

## Akar Masalah

`ExcelExportable::exportToExcel()` melakukan:

```php
$this->emit('flash.info', '...');   // (1)
$this->emit('beginExcelExport');    // (2)
```

Di Livewire 2, kedua emit() ini diarahkan kembali ke komponen yang sama (karena listener flash.info dari FlashComponent dan beginExcelExport dari trait). Browser lalu membuat request tambahan untuk memproses event tersebut, dan tiap request me-render ulang halaman → query laporan dijalankan berkali-kali per klik.

**Perubahan**
- app/Livewire/Concerns/ExcelExportable.php
- Hapus initializeExcelExportable() yang mendaftarkan listener exportToExcel & beginExcelExport (tidak ada kode lain yang emit event ini).
- exportToExcel() kini meng-set flash langsung (flashInfo) dan memanggil beginExcelExport() secara langsung, lalu mengembalikan StreamedResponse.
- Hasil: 1 klik → 1 request (sebelumnya 2 request berurutan), flash tetap tampil, file tetap ter-download.