### PR TITLE
fix: use explode instead of Str::words for status_pasien parsing

### DIFF
--- a/app/Models/Keuangan/NotaSelesai.php
+++ b/app/Models/Keuangan/NotaSelesai.php
@@ -146,7 +146,7 @@ class NotaSelesai extends Model
                     $ket = str($value->keterangan);
 
                     $bentukBayar = $ket->before('PASIEN')->words(1, '')->trim()->value();
-                    $statusPasien = str($ket->after('PASIEN'))->trim()->explode(' ')->take(2)->implode(' ');
+                    $statusPasien = $ket->after('PASIEN')->trim()->explode(' ')->take(2)->implode(' ');
                     $noRawat = $ket->matchAll('/\d+/')->take(4)->join('/');
                     $petugas = $ket->afterLast('OLEH ')->trim()->value();
 

--- a/app/Models/Keuangan/NotaSelesai.php
+++ b/app/Models/Keuangan/NotaSelesai.php
@@ -146,7 +146,7 @@ class NotaSelesai extends Model
                     $ket = str($value->keterangan);
 
                     $bentukBayar = $ket->before('PASIEN')->words(1, '')->trim()->value();
-                    $statusPasien = $ket->after('PASIEN')->words(2, '')->trim()->value();
+                    $statusPasien = str($ket->after('PASIEN'))->trim()->explode(' ')->take(2)->implode(' ');
                     $noRawat = $ket->matchAll('/\d+/')->take(4)->join('/');
                     $petugas = $ket->afterLast('OLEH ')->trim()->value();
 


### PR DESCRIPTION
## Problem

Menu Laporan Selesai Billing error saat memanggil `refreshModel()`:

SQLSTATE[22001]: String data, right truncated: 1406 Data too long
for column 'status_pasien' at row 48

## Root Cause

`Str::words()` internally uses `preg_match()` with the `/u` (UTF-8) modifier. 
Ketika field `jurnal.keterangan` mengandung karakter invalid UTF-8 
`preg_match` gagal dan `words()` mengembalikan seluruh string 
sebagai fallback, bukan hanya 2 kata pertama. String panjang ini 
melebihi kapasitas kolom `status_pasien` (VARCHAR(20)).

## Fix

`app/Models/Keuangan/NotaSelesai.php:149`

```php
// Before:
$statusPasien = $ket->after('PASIEN')->words(2, '')->trim()->value();

// After:
$statusPasien = $ket->after('PASIEN')->trim()->explode(' ')->take(2)->implode(' ');
explode() beroperasi di byte level tanpa regex UTF-8, sehingga tidak terpengaruh oleh karakter encoding yang tidak valid.